### PR TITLE
Default Codecs in reader(...) and writer(...) on Resource

### DIFF
--- a/core/src/main/scala/scalax/io/Resource.scala
+++ b/core/src/main/scala/scalax/io/Resource.scala
@@ -206,7 +206,7 @@ trait InputResource[+R <: Closeable] extends Resource[R] with Input with Resourc
      *
      * @return the [[scalax.io.ReadCharsResource]] version of this object.
      */
-    def reader(implicit sourceCodec: Codec) : ReadCharsResource[Reader]
+    def reader(implicit sourceCodec: Codec = Codec.UTF8) : ReadCharsResource[Reader]
     /**
      * Obtain the [[scalax.io.ReadableByteChannelResource]](typically) version of this object.
      *
@@ -251,7 +251,7 @@ trait OutputResource[+R <: Closeable] extends Resource[R] with Output with Resou
    *
    * @return the [[scalax.io.WriteCharsResource]] version of this object.
    */
-  def writer(implicit sourceCodec: Codec) : WriteCharsResource[Writer]
+  def writer(implicit sourceCodec: Codec = Codec.UTF8) : WriteCharsResource[Writer]
   /**
    * Obtain the [[scalax.io.WritableByteChannel]](typically) version of this object.
    *


### PR DESCRIPTION
Hi Jesse, 

Perhaps it was intentional, but noticed that I got a little bored of defining implicit Codecs when really all I ever wanted in each case is having a Codec.UTF8. So I was wondering if I could lure you into making that a default. If not, no worries.

Wilfred
