### PR TITLE
builds and tests properly

### DIFF
--- a/core/src/main/scala/scalax/io/processing/Processor.scala
+++ b/core/src/main/scala/scalax/io/processing/Processor.scala
@@ -2,8 +2,7 @@ package scalax.io
 package processing
 
 import scala.concurrent._
-import util.duration._
-import util.Duration
+import duration._
 
 /**
  * A point or step in a IO process workflow.

--- a/core/src/samples/scala/async-read-write.scala
+++ b/core/src/samples/scala/async-read-write.scala
@@ -99,7 +99,7 @@ object AsyncReadWrite {
    */
   def processorWithTimeOuts {
     import scalax.io.Resource
-    import scala.concurrent.util.duration._
+    import scala.concurrent.duration._
 
     val in = Resource.fromFile("/tmp/in")
     val out = Resource.fromFile("/tmp/out")

--- a/core/src/test/scala/scalaio/test/LongTraversableTest.scala
+++ b/core/src/test/scala/scalaio/test/LongTraversableTest.scala
@@ -8,7 +8,7 @@ import scalax.test.sugar._
 import java.io.IOException
 
 import scala.concurrent._
-import scala.concurrent.util.duration._
+import scala.concurrent.duration._
 
 class LongTraversableTest extends DataIndependentLongTraversableTest[Int] with ProcessorTest with AssertionSugar {
   implicit val codec = Codec.UTF8

--- a/core/src/test/scala/scalaio/test/ProcessorTest.scala
+++ b/core/src/test/scala/scalaio/test/ProcessorTest.scala
@@ -7,7 +7,7 @@ import java.util.concurrent.TimeoutException
 import scalax.io.{Resource, LongTraversable, ResourceContext, DefaultResourceContext}
 import java.io.{File, DataInputStream, ByteArrayInputStream}
 import scala.concurrent.Await
-import scala.concurrent.util.duration._
+import scala.concurrent.duration._
 
 trait ProcessorTest extends AssertionSugar {
   self: LongTraversableTest =>

--- a/core/src/test/scala/scalaio/test/processing/ProcessorAsyncTest.scala
+++ b/core/src/test/scala/scalaio/test/processing/ProcessorAsyncTest.scala
@@ -6,7 +6,7 @@ import org.junit.Assert._
 import scalax.io._
 import processing._
 import java.util.concurrent.TimeoutException
-import scala.concurrent.util.duration._
+import scala.concurrent.duration._
 import scala.util.{Success, Failure}
 
 class ProcessorAsyncTest extends AssertionSugar{

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -14,7 +14,7 @@ object ScalaIoBuild extends Build {
   // ----------------------- Root Project ----------------------- //
 
   lazy val root:Project = Project("root", file(".")).
-    aggregate(coreProject,fileProject,perfProject,webSiteProject).
+    aggregate(coreProject,fileProject,webSiteProject).
     settings(sharedSettings ++ Seq(publishArtifact := false, name := "Scala IO") :_*)
 
   // ----------------------- Samples Settings ----------------------- //


### PR DESCRIPTION
## motivation

Projects should be able to build and test.
## duration change

I changed all of the concurrency.util.duration references to concurrency.duration, because I think duration was moved into concurrency from concurrency.util.  I also removed the explicit reference to Duration, because it was moved into concurrency.duration.
## different behavior

Removed perfProject from the list of projects, so perfProject will not be build/compiled/run.  It does not currently work, because there is not a good build of sPerformance for scala 2.10.  I think all of the duration related code will still work fine.
