### PR TITLE
corrects Path.size per #58

### DIFF
--- a/core/src/main/scala/scalax/io/processing/Processor.scala
+++ b/core/src/main/scala/scalax/io/processing/Processor.scala
@@ -2,8 +2,7 @@ package scalax.io
 package processing
 
 import scala.concurrent._
-import util.duration._
-import util.Duration
+import duration._
 
 /**
  * A point or step in a IO process workflow.

--- a/core/src/samples/scala/async-read-write.scala
+++ b/core/src/samples/scala/async-read-write.scala
@@ -99,7 +99,7 @@ object AsyncReadWrite {
    */
   def processorWithTimeOuts {
     import scalax.io.Resource
-    import scala.concurrent.util.duration._
+    import scala.concurrent.duration._
 
     val in = Resource.fromFile("/tmp/in")
     val out = Resource.fromFile("/tmp/out")

--- a/core/src/test/scala/scalaio/test/LongTraversableTest.scala
+++ b/core/src/test/scala/scalaio/test/LongTraversableTest.scala
@@ -8,7 +8,7 @@ import scalax.test.sugar._
 import java.io.IOException
 
 import scala.concurrent._
-import scala.concurrent.util.duration._
+import scala.concurrent.duration._
 
 class LongTraversableTest extends DataIndependentLongTraversableTest[Int] with ProcessorTest with AssertionSugar {
   implicit val codec = Codec.UTF8

--- a/core/src/test/scala/scalaio/test/ProcessorTest.scala
+++ b/core/src/test/scala/scalaio/test/ProcessorTest.scala
@@ -7,7 +7,7 @@ import java.util.concurrent.TimeoutException
 import scalax.io.{Resource, LongTraversable, ResourceContext, DefaultResourceContext}
 import java.io.{File, DataInputStream, ByteArrayInputStream}
 import scala.concurrent.Await
-import scala.concurrent.util.duration._
+import scala.concurrent.duration._
 
 trait ProcessorTest extends AssertionSugar {
   self: LongTraversableTest =>

--- a/core/src/test/scala/scalaio/test/processing/ProcessorAsyncTest.scala
+++ b/core/src/test/scala/scalaio/test/processing/ProcessorAsyncTest.scala
@@ -6,7 +6,7 @@ import org.junit.Assert._
 import scalax.io._
 import processing._
 import java.util.concurrent.TimeoutException
-import scala.concurrent.util.duration._
+import scala.concurrent.duration._
 import scala.util.{Success, Failure}
 
 class ProcessorAsyncTest extends AssertionSugar{

--- a/file/src/main/scala/scalax/file/defaultfs/DefaultPath.scala
+++ b/file/src/main/scala/scalax/file/defaultfs/DefaultPath.scala
@@ -85,7 +85,10 @@ class DefaultPath private[file] (val jfile: JFile, override val fileSystem: Defa
   def isHidden = jfile.isHidden()
   def lastModified = jfile.lastModified()
   def lastModified_=(time: Long) = {jfile setLastModified time; time}
-  def size = if(jfile.exists) Some(jfile.length()) else None
+  def size = if(jfile.exists) jfile.length() match {
+    case 0 => None
+    case nonzero => Some(nonzero)
+  }  else None
 
   def access_=(accessModes:Iterable[AccessMode]) = {
     if (nonExistent) fail("Path %s does not exist".format(path))

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -14,7 +14,7 @@ object ScalaIoBuild extends Build {
   // ----------------------- Root Project ----------------------- //
 
   lazy val root:Project = Project("root", file(".")).
-    aggregate(coreProject,fileProject,perfProject,webSiteProject).
+    aggregate(coreProject,fileProject,webSiteProject).
     settings(sharedSettings ++ Seq(publishArtifact := false, name := "Scala IO") :_*)
 
   // ----------------------- Samples Settings ----------------------- //


### PR DESCRIPTION
## motivation

Fixes github issue #58, to the extent that it Path.size will return a None if the length is 0.  Semantically, it makes more sense to return a None for an empty file, rather than Some(0), since although a file was found, it was trivial.
## issue #58 completeness

Issue #58 mentions that it's unclear whether exists works or not, which is not covered by this pull request.  Probably, the issue should be closed, but a new issue should be opened to check that.
## testing

I wasn't sure where to put a test in for this, but it should be tested.
## different behavior

Previously, Path.size returned Some(0) for files that existed but were empty.  Now, it will instead return None.
## implementation choices

The existing implementation was a simple one-liner, 

``` scala
if (jfile.exists()) Some(jfile.length()) else None
```

This was incorrect, but it was unclear how to fix it in a way that preserved its clarity and efficiency.  The different ideas I toyed with were

``` scala
if (jfile.exists() && jfile.length() != 0) Some(jfile.length()) else None
```

This is the cleanest and the most straightforward, but I think that jfile.length() is not cached, and in the case where the file exists and is nonempty, will have to get a line length twice.

Another idea for how to implement it is to keep this clean system, but instead make it a block.

``` scala
{
  val length = jfile.length()
  if (jfile.exists() && length != 0) Some(length) else None
}
```

However, it requires using a block, which is unsightly.

Ultimately, I decided to go with something that looks ok, and that I guessed the compiler would probably optimize away anyway.  The biggest concern was to bind jfile.length() to a variable so that I didn't have to call it twice, so I used a match expression, which lets me both check its value and binds its contents.

``` scala
if (jfile.exissts()) jfile.length() match {
  case 0 => None
  case nonzero => Some(nonzero)
} else None
```

The value of the "if" part of the expression being a match expression is a little messy, which is distasteful, but I felt like adding another set of curly braces was worse.
