### PR TITLE
update build for scala 2.10.0 final

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -6,8 +6,8 @@ object BuildConstants {
   val organization = "com.github.scala-incubator.io"
   val version = "0.5.0-SNAPSHOT"
   val armVersion = "1.2"
-  val armScalaVersion = "2.10.0-M7"
-  val scalaVersion = "2.10.0-SNAPSHOT"
+  val armScalaVersion = "2.10"
+  val scalaVersion = "2.10.0"
 }
 
 object ScalaIoBuild extends Build {


### PR DESCRIPTION
Now that 2.10.0 final is out (though not yet announced), the build can be updated.  All tests pass.
