### PR TITLE
Update to Scala 2.10.0 final

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -7,7 +7,7 @@ object BuildConstants {
   val version = "0.5.0-SNAPSHOT"
   val armVersion = "1.2"
   val armScalaVersion = "2.10.0-M7"
-  val scalaVersion = "2.10.0-SNAPSHOT"
+  val scalaVersion = "2.10.0"
 }
 
 object ScalaIoBuild extends Build {


### PR DESCRIPTION
http://www.scala-lang.org/node/27499

This update compiles and passes tests without problems.

Incidentally, I've tried using the published [scala-io-file_2.10 v0.4.1 artifact](http://search.maven.org/#artifactdetails|com.github.scala-incubator.io|scala-io-file_2.10|0.4.1|jar) in a 2.10-based project, but unfortunately it fails:

```
java.lang.NoSuchMethodError: scala.LowPriorityImplicits.charWrapper(C)Lscala/runtime/RichChar;
    at scalax.file.FileSystem.<init>(FileSystem.scala:49)
    at scalax.file.defaultfs.DefaultFileSystem.<init>(DefaultFileSystem.scala:20)
```

In Scala 2.10.0 that [set of methods are now inlined](https://github.com/scala/scala/commit/d3f879a#diff-0), presumably causing the `NoSuchMethodError`. Recompiling against Scala 2.10.0 should fix it, I think!
