### PR TITLE
Scala 2.11 compatibility

### DIFF
--- a/file/src/main/scala/scalax/file/PathMatcher.scala
+++ b/file/src/main/scala/scalax/file/PathMatcher.scala
@@ -11,8 +11,6 @@ package scalax.file
 import scalax.file.PathMatcher.FunctionMatcher
 import util.matching.Regex
 import java.util.regex.Pattern
-import java.util.concurrent.{ConcurrentMap => JConcurrentMap}
-import collection.mutable.ConcurrentMap
 
 /**
  * A function that returns true if the Path parameter

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -96,9 +96,22 @@ object ScalaIoBuild extends Build {
     }
   })
 
+  // add scala-parser-combinators dependency when needed (for Scala 2.11 and newer) in a robust way
+  // this mechanism supports cross-version publishing
+  private val addScalaParserCombinatorsModule = libraryDependencies := {
+    CrossVersion.partialVersion(scalaVersion.value) match {
+      // if scala 2.11+ is used, add dependency on scala-parser-combinators module
+      case Some((2, scalaMajor)) if scalaMajor >= 11 =>
+        libraryDependencies.value :+ "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.0"
+      case _ =>
+        libraryDependencies.value
+    }
+  }
+
   val fileSettings: Seq[Setting[_]] = Seq(
     name := "scala-io-file",
-    pomPostProcess := removeScalaIOTestDependency.apply
+    pomPostProcess := removeScalaIOTestDependency.apply,
+    addScalaParserCombinatorsModule
   )
   lazy val fileProject = Project("file", file("file")).
     configs(Samples).

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.1.0")
+addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.4.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.1")
 


### PR DESCRIPTION
This PR makes scala-io Scala 2.11 compatible. The required changes were very minor.

scala-io project is included in the collection of open source projects that Scala team builds every night to detect regressions in Scala compiler. Once those changes are merged, we'll be able to migrate off our own fork of scala-io so speedy review is appreciated!
