### PR TITLE
Fix for released scala 2.11 parser artifacts

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -104,7 +104,7 @@ object ScalaIoBuild extends Build {
     CrossVersion.partialVersion(scalaVersion.value) match {
       // if scala 2.11+ is used, add dependency on scala-parser-combinators module
       case Some((2, scalaMajor)) if scalaMajor >= 11 =>
-        libraryDependencies.value :+ "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.0"
+        libraryDependencies.value :+ "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.1"
       case _ =>
         libraryDependencies.value
     }


### PR DESCRIPTION
Looks like version 1.0.0 of scala-parser-combinators was never published to Maven Central:

http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.scala-lang.modules%22%20AND%20a%3A%22scala-parser-combinators_2.11%22

You can see how this causes problems with this example build of The BFG:

https://travis-ci.org/rtyley/bfg-repo-cleaner/builds/24380719

```
sbt.ResolveException: unresolved dependency: org.scala-lang.modules#scala-parser-combinators_2.11;1.0.0: not found
```
