### PR TITLE
Fix acquireFor to not throw errors on resource open

### DIFF
--- a/file/src/test/scala/scalaio/test/AcquireForTest.scala
+++ b/file/src/test/scala/scalaio/test/AcquireForTest.scala
@@ -1,0 +1,27 @@
+package scalaio.test
+
+import java.io.{FileNotFoundException, InputStream}
+
+import org.junit.Test
+
+import scalax.file.Path
+
+/**
+  * Test that a file can be opened and that open errors are correctly populated in the resulting Either,
+  * and not rethrown, per the contract.
+  */
+class AcquireForTest {
+
+  def noop(stream: InputStream): Unit = {
+    // Not op'ing.
+  }
+
+  @Test
+  def test(): Unit = {
+    val result = Path.fromString("foobarfile").inputStream.acquireFor { noop }
+    result.either match {
+      case Left(seq) if seq.head.getClass == classOf[FileNotFoundException] => assert(true)
+      case _                                                                => assert(false)
+    }
+  }
+}


### PR DESCRIPTION
Resource's acquireFor was throwing exceptions like FileNotFound
when the resource was opened, even though the contract states that
errors would be caught and returned in the resulting either. This
change allows acquireFor to fulfill the specified contract.